### PR TITLE
Refactor startup script to use bash, streamline virtual environment s…

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,39 +1,24 @@
-#!/bin/sh
-set -e
-
+#!/bin/bash
 echo "Starting FastAPI application..."
 
-# Set default values for environment variables
-export WORKERS=${WORKERS:-4}
-export HOST=${HOST:-0.0.0.0}
-export PORT=${PORT:-8000}
+# Instalar dependencias si es necesario
+if [ ! -d "/home/site/wwwroot/.venv" ]; then
+    echo "Creating virtual environment..."
+    python -m venv /home/site/wwwroot/.venv
+    source /home/site/wwwroot/.venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
+else
+    source /home/site/wwwroot/.venv/bin/activate
+fi
 
-# Health check
-echo "Environment ready, virtual environment is already configured"
-
-# Execute database migrations when ready
+# Ejecutar migraciones de base de datos
+echo "Running database migrations..."
+alembic upgrade head
+# Ejecutar migraciones de base de datos (comentado hasta tener modelos)
 echo "Skipping database migrations - no models defined yet..."
 # alembic upgrade head
 
-# Detect OS and choose appropriate server
-if [ "$(uname -s)" = "Linux" ] || [ "$(uname -s)" = "Darwin" ]; then
-    # Unix-like systems: use gunicorn
-    echo "Starting application with gunicorn on ${HOST}:${PORT} with ${WORKERS} workers..."
-    exec uv run gunicorn app.main:app \
-        -w "$WORKERS" \
-        -k uvicorn.workers.UvicornWorker \
-        --bind "${HOST}:${PORT}" \
-        --access-logfile - \
-        --error-logfile - \
-        --max-requests 1000 \
-        --max-requests-jitter 100 \
-        --preload
-else
-    # Windows: use uvicorn directly (gunicorn doesn't work on Windows)
-    echo "Starting application with uvicorn on ${HOST}:${PORT} (Windows detected)..."
-    exec uv run uvicorn app.main:app \
-        --host "$HOST" \
-        --port "$PORT" \
-        --access-log \
-        --log-level info
-fi
+# Iniciar la aplicación
+echo "Starting application with gunicorn..."
+exec gunicorn --bind=0.0.0.0:8000 --workers=4 --worker-class=uvicorn.workers.UvicornWorker app.main:app


### PR DESCRIPTION

This pull request updates the `startup.sh` script to improve environment setup and simplify application startup. The script now ensures the Python virtual environment is created and dependencies are installed if needed, and it always runs database migrations before starting the application. The logic for starting the server has been simplified to always use Gunicorn, regardless of the operating system.

**Environment setup improvements:**

* The script now checks for the existence of the `.venv` directory and creates a virtual environment and installs dependencies if not present.
* Default environment variable assignments for `WORKERS`, `HOST`, and `PORT` have been removed.

**Database migration handling:**

* The script now runs `alembic upgrade head` to apply database migrations before starting the server, with a placeholder message indicating migrations are skipped if no models are defined.

**Server startup simplification:**

* The logic for detecting the operating system and conditionally starting with Gunicorn or Uvicorn has been removed; the script now always starts the application with Gunicorn.