### PR TITLE
Update CI and deployment workflows to restrict branch triggers for prod and dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - Tests and Validation
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ prod ]
   pull_request:
-    branches: [ main ]
+    branches: [ prod ]
 
 jobs:
   test:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,7 +2,7 @@ name: Deploy to Development
 
 on:
   push:
-    branches: [ develop, main ]
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,7 +2,7 @@ name: Deploy to Production
 
 on:
   push:
-    branches: [ prod ]
+    branches: [ production ]
     tags: [ 'v*' ]
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request updates the branch filters for the project's GitHub Actions workflows to better align with the intended deployment and CI/CD processes. The main changes involve adjusting which branches trigger specific workflows.

**Workflow configuration updates:**

- **Continuous Integration and Validation:**
  * The `CI - Tests and Validation` workflow now only runs on pushes and pull requests to the `prod` branch (previously `main` and `develop`).

- **Development Deployment:**
  * The `Deploy to Development` workflow is now triggered only by pushes to the `develop` branch (previously also included `main`).

- **Production Deployment:**
  * The `Deploy to Production` workflow now listens for pushes to the `production` branch (previously `prod`).