### PR TITLE
Refactor authentication module to use settings directly instead of get_settings

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from .settings import get_settings
+from .settings import settings
 
 security = HTTPBasic()
 
@@ -19,7 +19,6 @@ def authenticate_docs(
     Authenticate users for API documentation access.
     Uses HTTP Basic Authentication with configurable credentials.
     """
-    settings = get_settings()
     
     # If docs authentication is disabled, allow access
     if not settings.ENABLE_DOCS_AUTH:
@@ -52,5 +51,4 @@ def get_docs_auth_dependency():
     Get the authentication dependency for docs.
     Returns None if authentication is disabled.
     """
-    settings = get_settings()
     return authenticate_docs if settings.ENABLE_DOCS_AUTH else None


### PR DESCRIPTION
This pull request simplifies how application settings are accessed in the authentication module by switching from a function-based approach to directly importing the `settings` object. This results in cleaner and more consistent code within the authentication logic.

Refactoring for settings access:

* Replaced usage of the `get_settings()` function with direct import of the `settings` object in `app/auth.py`, including in the `authenticate_docs` and `get_docs_auth_dependency` functions. [[1]](diffhunk://#diff-0f066672bb2866831c8a0b61c48c718390334d798b547ee7519b20977c2b8653L10-R10) [[2]](diffhunk://#diff-0f066672bb2866831c8a0b61c48c718390334d798b547ee7519b20977c2b8653L22) [[3]](diffhunk://#diff-0f066672bb2866831c8a0b61c48c718390334d798b547ee7519b20977c2b8653L55)