### PR TITLE
Refactor database connection settings to use psycopg2; update requirements and startup script for migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,9 +11,8 @@ from alembic import context
 # Add the app directory to the path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-# Import settings and models
+# Import settings
 from app.settings import settings
-from app.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -24,12 +23,15 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Set the SQLAlchemy URL from settings
-config.set_main_option("sqlalchemy.url", str(settings.SQLALCHEMY_DATABASE_URI))
+# Set the SQLAlchemy URL from settings (now using psycopg2)
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-target_metadata = Base.metadata
+# TODO: Import models when they are created
+# from app.models import Base
+# target_metadata = Base.metadata
+target_metadata = None
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/app/settings.py
+++ b/app/settings.py
@@ -81,14 +81,16 @@ class Settings(BaseSettings):
         # First try to use complete DATABASE_URL (as Azure Web App provides it)
         database_url = os.environ.get("DATABASE_URL")
         if database_url:
-            # Convert to asyncpg if necessary
+            # Convert to psycopg2 for synchronous operations
             if database_url.startswith("postgresql://"):
-                database_url = database_url.replace("postgresql://", "postgresql+asyncpg://")
+                database_url = database_url.replace("postgresql://", "postgresql+psycopg2://")
+            elif database_url.startswith("postgresql+asyncpg://"):
+                database_url = database_url.replace("postgresql+asyncpg://", "postgresql+psycopg2://")
             return PostgresDsn(database_url)
         
         # If DATABASE_URL doesn't exist, build from individual components
         return PostgresDsn.build(
-            scheme="postgresql+asyncpg",  # Changed to use asyncpg
+            scheme="postgresql+psycopg2",  # Use psycopg2 for synchronous operations
             username=self.PG_USER,
             password=self.PG_PASSWORD,
             host=self.PG_SERVER,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-decouple==3.8
 asyncpg==0.29.0
+psycopg2-binary==2.9.9
 alembic==1.16.5
 openai>=1.109.1
 pydantic-settings>=2.11.0

--- a/startup.sh
+++ b/startup.sh
@@ -44,8 +44,8 @@ fi
 
 # Ejecutar migraciones de base de datos
 echo "Running database migrations..."
-echo "Skipping database migrations - no models defined yet..."
-# alembic upgrade head
+# echo "Skipping database migrations - no models defined yet..."
+alembic upgrade head
 
 # Start the application
 echo "Starting application with gunicorn using $WORKERS worker(s)..."


### PR DESCRIPTION
This pull request updates the database migration configuration and startup process to use the synchronous `psycopg2` database driver instead of the asynchronous `asyncpg` driver. It also enables running Alembic migrations by default, and temporarily disables autogeneration of migration scripts until models are defined.

Database driver and Alembic configuration:

* Updated the construction of the SQLAlchemy database URI in `app/settings.py` to use the `psycopg2` driver for synchronous operations, replacing any `asyncpg` references with `psycopg2`.
* Changed the Alembic configuration in `alembic/env.py` to use the new `DATABASE_URL` with `psycopg2` instead of the previous async URI, and removed the direct import of models for now. [[1]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630L14-L16) [[2]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630L27-R34)

Database migrations process:

* Modified `startup.sh` to run Alembic migrations by default instead of skipping them, enabling database schema updates on startup.